### PR TITLE
fix: Make backward compatible to flow 24.0.0 version with the AriaLabel fix.

### DIFF
--- a/src/main/java/com/example/application/views/FormFillerTextView.java
+++ b/src/main/java/com/example/application/views/FormFillerTextView.java
@@ -75,7 +75,7 @@ public class FormFillerTextView extends Main {
         templates.addClassNames(LumoUtility.Flex.GROW);
         templates.addValueChangeListener(e -> textArea.setValue(getExampleTexts().get(templates.getValue())));
         templates.setAllowCustomValue(false);
-        templates.setAriaLabel("Templates");
+        templates.getElement().setProperty("accessibleName", "Templates");
         templates.setItems("Template 001", "Template 002", "Template 003");
         templates.setTooltipText("Select a pre-defined raw text example that you want to fill in the form");
         templates.setPlaceholder("Select template...");


### PR DESCRIPTION
## Description
After testing the demo with the form filler addon with `24.0.0` flow version, the replaced code was causing a compilation error as it was not implemented in this flow version:

`templates.setAriaLabel("Templates");`

As the method implementation is this:
```java
    @Override
    public void setAriaLabel(String ariaLabel) {
        getElement().setProperty("accessibleName", ariaLabel);
    }
```

## We can make the changes in the PR.

In the pom.xml, change the `vaadin.version` to this:
```
        <vaadin.version>24.0.0</vaadin.version>
```

Potentially you need `mvn clean` and/or `mvn vaadin:dance`. 
Thanks, Mikhail for the help clearing out client-server flow caused error messages and flow insights 🙇 


To test the changes:


## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
