### PR TITLE
chore: Update to V24.2 pre and add feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This project is a showcase example of using [Vaadin Form Filler add-on](https://
 and helps to automate a filling in the order information.
 Users can input their raw unstructured text and ask the application to auto-fill the form on the right side.
 
+Uses Form Filler 1.0 and based on Vaadin 24.2 pre-release.
+To use latest stable Vaadin 24.1 version, please use `24.1` branch.
+
 ## Running the Application
 
 To run the application you will need a valid ChatGPT API key.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This project is a showcase example of using [Vaadin Form Filler add-on](https://github.com/vaadin/form-filler-addon) and helps to automate a filling in the order information.
 Users can input their raw unstructured text and ask the application to auto-fill the form on the right side.
 
-Uses Form Filler 1.0.0 and based on Vaadin 24.2+.
-To use latest stable Vaadin 24.1 version, please switch to `24.1` branch.
+`main` branch uses Form Filler 1.0.0 pre-release and based on Vaadin 24.2 pre-release.
+`24.1` branch uses latest stable Vaadin 24.1 version and Form filler 0.1.
 
 Please note that the Form Filler add-on is currently an experimental feature. 
 It may be removed, altered, or limited to commercial subscribers in future releases.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ export OPENAI_TOKEN="THE KEY"
 ```
 - Windows: Use "System -> Advanced Settings -> Set Environment Variables" to set OPENAI_TOKEN
 
-The project is a standard Maven project. To run it from the command line, type `mvn` and open http://localhost:8080 in your browser.
+The project is a standard Maven project. To run it from the command line, type `mvnw` and open http://localhost:8080 in your browser.
 
 You can also import the project to your IDE of choice as you would with any
 Maven project. Read more on [how to set up a development environment for
@@ -43,7 +43,7 @@ You can play with the input text (remove parts, make a syntax mistakes) and see 
 
 Integration tests are implemented using [Vaadin TestBench](https://vaadin.com/testbench). The tests take a few minutes to run and are therefore included in a separate Maven profile. We recommend running tests with a production build to minimize the chance of development time toolchains affecting test stability. To run the tests using Google Chrome, execute
 
-`mvn verify -Pit,production`
+`mvnw verify -Pit,production`
 
 and make sure you have a valid TestBench license installed (you can obtain a trial license from the [trial page](https://vaadin.com/trial)).
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ export OPENAI_TOKEN="THE KEY"
 - Windows: Use "System -> Advanced Settings -> Set Environment Variables" to set OPENAI_TOKEN
 
 The project is a standard Maven project. To run it from the command line, type `mvnw` and open http://localhost:8080 in your browser.
+To run the `mvnw` command, you may need to specify it differently depending on your operating system:
+- Windows: Use `mvnw` directly in your command prompt.
+- macOS/Unix: You may need to prepend `./` to the command, like this: `./mvnw`.
 
 You can also import the project to your IDE of choice as you would with any
 Maven project. Read more on [how to set up a development environment for

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Vaadin Form Filler demo project 
 
-This project is a showcase example of using [Vaadin Form Filler add-on](https://github.com/vaadin/form-filler-addon)
-and helps to automate a filling in the order information.
+This project is a showcase example of using [Vaadin Form Filler add-on](https://github.com/vaadin/form-filler-addon) and helps to automate a filling in the order information.
 Users can input their raw unstructured text and ask the application to auto-fill the form on the right side.
 
-Uses Form Filler 1.0 and based on Vaadin 24.2 pre-release.
-To use latest stable Vaadin 24.1 version, please use `24.1` branch.
+Uses Form Filler 1.0.0 and based on Vaadin 24.2+.
+To use latest stable Vaadin 24.1 version, please switch to `24.1` branch.
+
+Please note that the Form Filler add-on is currently an experimental feature. 
+It may be removed, altered, or limited to commercial subscribers in future releases.
 
 ## Running the Application
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,7 @@ export OPENAI_TOKEN="THE KEY"
 ```
 - Windows: Use "System -> Advanced Settings -> Set Environment Variables" to set OPENAI_TOKEN
 
-The project is a standard Maven project. To run it from the command line, type `mvnw` and open http://localhost:8080 in your browser.
-To run the `mvnw` command, you may need to specify it differently depending on your operating system:
-- Windows: Use `mvnw` directly in your command prompt.
-- macOS/Unix: You may need to prepend `./` to the command, like this: `./mvnw`.
+The project is a standard Maven project. To run it from the command line, type `mvnw` (Windows) or `./mvnw` (macOs/Unix) and open http://localhost:8080 in your browser.
 
 You can also import the project to your IDE of choice as you would with any
 Maven project. Read more on [how to set up a development environment for
@@ -48,7 +45,8 @@ You can play with the input text (remove parts, make a syntax mistakes) and see 
 
 Integration tests are implemented using [Vaadin TestBench](https://vaadin.com/testbench). The tests take a few minutes to run and are therefore included in a separate Maven profile. We recommend running tests with a production build to minimize the chance of development time toolchains affecting test stability. To run the tests using Google Chrome, execute
 
-`mvnw verify -Pit,production`
+Windows: `mvnw verify -Pit,production`
+macOs/Unix: `./mvnw verify -Pit,production`
 
 and make sure you have a valid TestBench license installed (you can obtain a trial license from the [trial page](https://vaadin.com/trial)).
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <vaadin.version>24.2.0.alpha10</vaadin.version>
+        <vaadin.version>24.2.0.alpha11</vaadin.version>
     </properties>
 
     <parent>
@@ -109,7 +109,6 @@
         <dependency>
             <groupId>com.vaadin.flow.ai</groupId>
             <artifactId>form-filler-addon</artifactId>
-            <version>1.0.0.alpha1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <vaadin.version>24.1.7</vaadin.version>
+        <vaadin.version>24.2.0.alpha10</vaadin.version>
     </properties>
 
     <parent>
@@ -50,12 +50,12 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-        </pluginRepository>        
+        </pluginRepository>
         <pluginRepository>
             <id>vaadin-prereleases</id>
             <url>
                 https://maven.vaadin.com/vaadin-prereleases/
-            </url>            
+            </url>
         </pluginRepository>
     </pluginRepositories>
 
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>com.vaadin.flow.ai</groupId>
             <artifactId>form-filler-addon</artifactId>
-            <version>0.1.0</version>
+            <version>1.0.0.alpha1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/vaadin-featureflags.properties
+++ b/src/main/resources/vaadin-featureflags.properties
@@ -1,2 +1,3 @@
 # SideNav component (Production ready but tweaks to at least the internal DOM will still take place)
 com.vaadin.experimental.sideNavComponent=true
+com.vaadin.experimental.formFillerAddon=true


### PR DESCRIPTION
Explicit Form Filler dependency can be removed when we add the Form Filler to the platform.