### PR TITLE
chore: Add system property to config

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,17 +30,16 @@ jobs:
         TBL=${{ secrets.TB_LICENSE }}
         [ -z "$TBL" ] && echo "No TB license provided" && exit 1
         mkdir -p ~/.vaadin/
-        echo '{"username":"'`echo $TBL | cut -d / -f1`'","proKey":"'`echo $TBL | cut -d / -f2`'"}' > ~/.vaadin/proKey 
+        echo '{"username":"'`echo $TBL | cut -d / -f1`'","proKey":"'`echo $TBL | cut -d / -f2`'"}' > ~/.vaadin/proKey
     - uses: browser-actions/setup-chrome@latest
       with:
         chrome-version: stable
-    - uses: nanasess/setup-chromedriver@master 
+    - uses: nanasess/setup-chromedriver@master
     - name: Build with Maven
       run: |
-        [ -z "$OPENAI_TOKEN" ] && echo "No OpenAI token provided" && exit 1
-        mvn -ntp -B verify -Pit --file pom.xml -Dcom.vaadin.testbench.Parameters.headless=true
-      env:
-        OPENAI_TOKEN: ${{ secrets.OPENAI_TOKEN }}
+        TOKEN=${{ secrets.OPENAI_TOKEN }}
+        [ -z "$TOKEN" ] && echo "No OpenAI token provided" && exit 1
+        mvn -ntp -B verify -Pit -DOPENAI_TOKEN="$TOKEN" --file pom.xml -Dcom.vaadin.testbench.Parameters.headless=true
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
       uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/README.md
+++ b/README.md
@@ -15,15 +15,19 @@ To run the application you will need a valid ChatGPT API key.
 You can get it by registering on [OpenAI website](https://platform.openai.com/overview).
 Choose 'Sign up' and follow the instructions.
 
-This key can be set as environment variable or specified from command line with the '-D' flag.
+This key can be set as system property with '-D' flag or as an environment variable:
 
-- Macos: include on your .zprofile
-```script
-export OPENAI_TOKEN="THE KEY"
-```
-- Windows: Use "System -> Advanced Settings -> Set Environment Variables" to set OPENAI_TOKEN
+- System property: add `-DOPENAI_TOKEN=your_key` to your command in console.
+- Environment variable:
+   - Macos: include on your .zprofile
+   ```script
+   export OPENAI_TOKEN="THE KEY"
+   ```
+   - Windows: Use "System -> Advanced Settings -> Set Environment Variables" to set OPENAI_TOKEN
 
 The project is a standard Maven project. To run it from the command line, type `mvnw` (Windows) or `./mvnw` (macOs/Unix) and open http://localhost:8080 in your browser.
+With a system property it would be `mvnw -DOPENAI_TOKEN=your_key` (Windows) or `./mvnw -DOPENAI_TOKEN=your_key` (macOs/Unix).
+This will run the project in [development mode](https://vaadin.com/docs/latest/configuration/development-mode).
 
 You can also import the project to your IDE of choice as you would with any
 Maven project. Read more on [how to set up a development environment for
@@ -40,6 +44,11 @@ It might take a few seconds until AI responses back, you would see the loading i
 Finally, you shall see the values in the form fields and also orders list on the bottom of the page.
 
 You can play with the input text (remove parts, make a syntax mistakes) and see how AI will interpret them.
+
+### Running in production mode
+To run the application in [production mode](https://vaadin.com/docs/latest/production), you need:
+- build the jar with `mvnw clean package -Pproduction` (Windows) or `./mvnw clean package -Production` (macOs/Unix)
+- run jar with `java -DOPENAI_TOKEN=your_key -jar target/formfillerdemo-1.0-SNAPSHOT.jar`
 
 ### Running Integration Tests
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <properties>
         <java.version>17</java.version>
         <vaadin.version>24.2.0.alpha11</vaadin.version>
+        <OPENAI_TOKEN></OPENAI_TOKEN>
     </properties>
 
     <parent>
@@ -122,6 +123,9 @@
                     <jvmArguments>-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5371</jvmArguments>
                     <wait>500</wait>
                     <maxAttempts>240</maxAttempts>
+                    <systemPropertyVariables>
+                        <OPENAI_TOKEN>${OPENAI_TOKEN}</OPENAI_TOKEN>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,11 @@
                     <plugin>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <OPENAI_TOKEN>${OPENAI_TOKEN}</OPENAI_TOKEN>
+                            </systemPropertyVariables>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>start-spring-boot</id>


### PR DESCRIPTION
Passes system property to the maven plugin so that the project can be started with `mvn -DOPENAI_TOKEN=your_key`.

Fixes https://github.com/vaadin/form-filler-demo/issues/5